### PR TITLE
Update mermaid version to 11.6.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ author:
 
 # Mermaid settings
 mermaid:
-  version: "9.1.3"  # Pick the version you want
+  version: "11.6.0"  # Pick the version you want
   # Default configuration
   config: |
     directionLR


### PR DESCRIPTION
Uses very old version of mermaid.
Noticed that 11.6.0 version doesn't produce very wide empty spaces below and under flowcharts/sequenceDiagrams, etc.

edit: but maybe this was the point of using this version, that maybe it looks a bit more orderly with wide spaces (but they are often too wide)? Can check how 11.6.0 looks [here](https://mnbnkr.github.io/mach-codebase-tutorial/).