### PR TITLE
update mermaid to 10.9.3

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ author:
 
 # Mermaid settings
 mermaid:
-  version: "11.6.0"  # Pick the version you want
+  version: "10.9.3"  # Pick the version you want
   # Default configuration
   config: |
     directionLR


### PR DESCRIPTION
(fixes `codespan` formatting incompatibility of newer releases (current 11.6.0))

This version removes the wide empty spaces above and below flowcharts, sequenceDiagrams etc. But still allows `codespan` (something newer versions don't).