### PR TITLE
fix (dependencies): add openai to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gitpython>=3.1.0
 google-cloud-aiplatform>=1.25.0
 google-genai>=1.9.0
 python-dotenv>=1.0.0
+openai>=1.76.0


### PR DESCRIPTION
## Why?

I chose to use the openai version of `call_llm` and when I tried it errored out because if didn't find the openai dependency.

## How?

I added `openai>=1.76.0` to `requirements.txt`, ran `pip install -r requirements.txt`, and then it worked as expected.