### PR TITLE
fix: skip relationships with invalid indices instead of crashing

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -379,21 +379,23 @@ Now, provide the YAML output:
             try:
                 from_idx = int(str(rel["from_abstraction"]).split("#")[0].strip())
                 to_idx = int(str(rel["to_abstraction"]).split("#")[0].strip())
-                if not (
-                    0 <= from_idx < num_abstractions and 0 <= to_idx < num_abstractions
-                ):
-                    raise ValueError(
-                        f"Invalid index in relationship: from={from_idx}, to={to_idx}. Max index is {num_abstractions-1}."
-                    )
-                validated_relationships.append(
-                    {
-                        "from": from_idx,
-                        "to": to_idx,
-                        "label": rel["label"],  # Potentially translated label
-                    }
-                )
             except (ValueError, TypeError):
-                raise ValueError(f"Could not parse indices from relationship: {rel}")
+                print(f"Warning: Could not parse indices from relationship, skipping: {rel}")
+                continue
+            if not (
+                0 <= from_idx < num_abstractions and 0 <= to_idx < num_abstractions
+            ):
+                print(
+                    f"Warning: Invalid index in relationship (from={from_idx}, to={to_idx}, max={num_abstractions-1}), skipping."
+                )
+                continue
+            validated_relationships.append(
+                {
+                    "from": from_idx,
+                    "to": to_idx,
+                    "label": rel["label"],  # Potentially translated label
+                }
+            )
 
         print("Generated project summary and relationship details.")
         return {


### PR DESCRIPTION
Fixes #161

## Problem

When the LLM returns relationship indices that are out of bounds (e.g., `to=10` when only 10 abstractions exist with max valid index `9`), the code raises a `ValueError` inside a `try` block, which is immediately caught by the `except (ValueError, TypeError)` clause and re-raised as a confusing `"Could not parse indices from relationship"` error. This causes the entire tutorial generation to crash.

Example error from the issue:
```
ValueError: Invalid index in relationship: from=9, to=10. Max index is 9.
ValueError: Could not parse indices from relationship: {'from_abstraction': 9, 'to_abstraction': 10, 'label': 'Uses debug'}
```

## Solution

Separate the index parsing (`int()` conversion) from the bounds validation:

1. Try to parse the integer indices — if parsing fails (non-numeric value), log a warning and **skip** the relationship.
2. After parsing succeeds, check bounds — if out of range, log a warning and **skip** the relationship.

This makes the pipeline resilient to LLM hallucinations that produce slightly out-of-bounds indices, rather than crashing the entire run.

## Testing

The fix handles both failure modes:
- Non-parseable values (e.g., `"abc"`) → caught by `except (ValueError, TypeError)`, skipped with warning
- Out-of-range indices (e.g., `from=9, to=10` with max=9) → caught by the bounds check, skipped with warning